### PR TITLE
feat(cli): add loading spinner during workflow dispatch

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -202,10 +202,12 @@ const shouldContinue = await confirm({
   message: `${displayInfo}\n\nDo you want to continue?`,
 });
 
+s.start("Running Workflow");
 if (shouldContinue) {
   const { stdout } = await execa("gh", workflowRunArgs);
   log.step(`Done ! Result : ${stdout}`);
 }
+s.stop();
 
 const shouldOpen = await confirm({
   message: "Do you want to open the workflow in the web ui?",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runr",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Start spinner before executing the workflow run command to provide visual feedback
- Stop spinner immediately after execution completes
- Bump package version to 1.0.1